### PR TITLE
Memory leak fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ print(torch.allclose(points_query.grad, grad_comp)) #Should print True
 
 Prerequisites
 -------------
+- Python <= 3.10 (3.11 and onwards are incompatible with the provided version of pybind11)
 - Numpy (installed with `setuptools`)
 - Torch (installed with `setuptools`)
 - Cuda

--- a/src/cutils.cuh
+++ b/src/cutils.cuh
@@ -159,7 +159,7 @@ template <typename T>
 __device__ inline void copyKernel(const T* src, const T* src_end, T* dest)
 {
 	//2D indices
-	const int blockidx = blockIdx.x + blockIdx.y*gridDim.x;
+	//const int blockidx = blockIdx.x + blockIdx.y*gridDim.x;
 	const int block_size = blockDim.x * blockDim.y; // * blockDim.z;
 	const int tidx = threadIdx.y * blockDim.x + threadIdx.x;
 
@@ -185,7 +185,7 @@ template <typename T>
 __device__ inline void fillKernel(T* src, T* src_end, T val)
 {
 	//2D indices
-	const int blockidx = blockIdx.x + blockIdx.y*gridDim.x;
+	//const int blockidx = blockIdx.x + blockIdx.y*gridDim.x;
 	const int block_size = blockDim.x * blockDim.y; // * blockDim.z;
 	const int tidx = threadIdx.y * blockDim.x + threadIdx.x;
 
@@ -284,7 +284,7 @@ template <typename T, uint32_t dims>
 __device__ inline void compDists(const Vec<T, dims>& point, const Vec<T, dims>* ref_leaf, const size_t nr_ref, T* dest)
 {
 	//2D indices
-	const int blockidx = blockIdx.x + blockIdx.y*gridDim.x;
+	//const int blockidx = blockIdx.x + blockIdx.y*gridDim.x;
 	const int block_size = blockDim.x * blockDim.y; // * blockDim.z;
 	const int tidx = threadIdx.y * blockDim.x + threadIdx.x;
 

--- a/src/kdtree.hpp
+++ b/src/kdtree.hpp
@@ -199,6 +199,8 @@ struct PartitionInfo
         {
             delete partitions;
             delete leaves;
+            delete structured_points;
+            delete shuffled_inds;
         }
     }
 };
@@ -345,7 +347,7 @@ public:
         const NodeTag old_byte = visited_info[byte_idx];
         const NodeTag modified_mask = moveTagToBinaryPosition(NodeTag::left_right_visited); //getBinaryIndMask();
         const NodeTag unmodified_mask = static_cast<NodeTag>(~modified_mask);
-        const unsigned char bit_idx  = current_lin_ind % 4;
+        //const unsigned char bit_idx  = current_lin_ind % 4;
         visited_info[byte_idx] = static_cast<NodeTag>((unmodified_mask & old_byte) | (moveTagToBinaryPosition(new_bits) & modified_mask));
     }
 

--- a/src/kdtree_g.cu
+++ b/src/kdtree_g.cu
@@ -14,12 +14,9 @@ __device__ void compQuadrDistLeafPartitionBlockwise(const Vec<T, dims>& point, c
 									const point_i_knn_t nr_nns_searches, T& worst_dist)
 {
 	//2D indices
-	const int block_size = blockDim.x * blockDim.y;
-	const int tidx = threadIdx.y * blockDim.x + threadIdx.x;
+	//const int block_size = blockDim.x * blockDim.y;
+	//const int tidx = threadIdx.y * blockDim.x + threadIdx.x;
 
-    /*printf("compQuadrDistLeafPartition: %x, ", partition_leaf.data);
-    printf("%d, ", partition_leaf.nr_points);
-	printf("%d\n", partition_leaf.offset);*/
 	const Vec<T, dims>* partition_data = reinterpret_cast<Vec<T, dims>*>(partition_leaf.data);
     const point_i_t partition_size = partition_leaf.nr_points;
 	const point_i_t partition_offset = partition_leaf.offset;
@@ -300,14 +297,9 @@ __global__ void KDTreeKernel(PartitionInfoDevice<T, dims>* partition_info,
 	//2D indices
 	const auto grid_size = gridDim.x * gridDim.y;
 	const auto blockidx = blockIdx.x + blockIdx.y*gridDim.x;
-	const auto block_size = blockDim.x * blockDim.y; // * blockDim.z;
+	//const auto block_size = blockDim.x * blockDim.y; // * blockDim.z;
 	const auto tidx = threadIdx.y * blockDim.x + threadIdx.x;
-	//const auto global_start_idx = tidx + blockidx * grid_size;
 
-	//extern __shared__ char* shared_mem;
-	//__shared__ Vec<T, dims> buffered_query_points[nr_buffered_query_points];
-	//__shared__ Vec<T, dims> buffered_query_points_proj[nr_buffered_query_points];
-	//__shared__ tree_ind_t leaf_inds[nr_buffered_leaf_inds];
 	__shared__ point_i_t buffered_knn[2*max_nr_nns_searches];
 	__shared__ T buffered_dists[2*max_nr_nns_searches];
 	__shared__ TreeTraversal<T, dims> tree[1];

--- a/src/nndistance_g.cu
+++ b/src/nndistance_g.cu
@@ -81,7 +81,7 @@ __global__ void NmDistanceKernelDynamic(int n, const T* points_ref, int m, const
 	__shared__ T ref_buf[batch*point_dims];
 
 	//2D indices
-	const int blockidx = blockIdx.x + blockIdx.y*gridDim.x;
+	//const int blockidx = blockIdx.x + blockIdx.y*gridDim.x;
 	const int block_size = blockDim.x * blockDim.y; 
 	const int tidx = threadIdx.y * blockDim.x + threadIdx.x;
 	uint32_t* best_i = dev_all_best_i + tidx * nr_nns_searches;


### PR DESCRIPTION
Fixed a memory leak, resulting from missing deletes in the PartitionInfo (see #1)
Commented a few unused variables to reduce the number of warnings. Deleted some commented code.
Updated the README to reflect the pybind incompatibility with python versions >= 3.11.